### PR TITLE
feat: Implement initial frontend for email validation service

### DIFF
--- a/frontend/app/contact/page.tsx
+++ b/frontend/app/contact/page.tsx
@@ -1,0 +1,105 @@
+"use client"; // For form handling
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import Link from "next/link"; // For Next.js links
+
+export default function ContactPage() {
+  const [formData, setFormData] = useState({
+    name: "",
+    email: "",
+    subject: "",
+    message: "",
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setFormData({ ...formData, [e.target.id]: e.target.value });
+  };
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    console.log("Contact form submitted:", formData);
+    alert("Message sent! (This is a demo)");
+    // Reset form (optional)
+    setFormData({ name: "", email: "", subject: "", message: "" });
+  };
+
+  return (
+    <div className="container mx-auto px-4 py-12">
+      <div className="text-center mb-12">
+        <h1 className="text-4xl md:text-5xl font-bold text-primary">Get In Touch</h1>
+        <p className="text-lg text-muted-foreground mt-2">
+          Have questions or feedback? We'd love to hear from you.
+        </p>
+      </div>
+
+      <div className="grid md:grid-cols-2 gap-12 max-w-4xl mx-auto">
+        {/* Contact Form */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Send us a Message</CardTitle>
+            <CardDescription>Fill out the form below and we'll get back to you as soon as possible.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <Label htmlFor="name">Full Name</Label>
+                <Input id="name" value={formData.name} onChange={handleChange} placeholder="Your Name" required />
+              </div>
+              <div>
+                <Label htmlFor="email">Email Address</Label>
+                <Input id="email" type="email" value={formData.email} onChange={handleChange} placeholder="you@example.com" required />
+              </div>
+              <div>
+                <Label htmlFor="subject">Subject</Label>
+                <Input id="subject" value={formData.subject} onChange={handleChange} placeholder="How can we help?" required />
+              </div>
+              <div>
+                <Label htmlFor="message">Message</Label>
+                <Textarea id="message" value={formData.message} onChange={handleChange} placeholder="Your message..." rows={5} required />
+              </div>
+              <Button type="submit" className="w-full">Send Message</Button>
+            </form>
+          </CardContent>
+        </Card>
+
+        {/* Alternative Contact Methods */}
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Other Ways to Reach Us</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div>
+                <h3 className="font-semibold">Email Us Directly</h3>
+                <p className="text-muted-foreground">
+                  For general inquiries or support, you can email us at:
+                  <br />
+                  <a href="mailto:support@example-validation.com" className="text-primary hover:underline">
+                    support@example-validation.com 
+                  </a> {/* Placeholder email */}
+                </p>
+              </div>
+              <div>
+                <h3 className="font-semibold">Frequently Asked Questions</h3>
+                <p className="text-muted-foreground">
+                  Check out our <Link href="/faq" className="text-primary hover:underline">FAQ page</Link> for answers to common questions.
+                </p>
+              </div>
+              <div>
+                <h3 className="font-semibold">API Documentation</h3>
+                <p className="text-muted-foreground">
+                  Need help with integration? Visit our <Link href="/api-docs" className="text-primary hover:underline">API Documentation</Link>.
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/pricing/page.tsx
+++ b/frontend/app/pricing/page.tsx
@@ -1,0 +1,88 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { CheckIcon } from "lucide-react"; // Or a simple text checkmark '✓' if lucide-react is not installed
+
+// Helper component for feature list items
+const FeatureListItem = ({ children }: { children: React.ReactNode }) => (
+  <li className="flex items-center">
+    <CheckIcon className="w-4 h-4 mr-2 text-primary" /> {/* Replace with '✓' if CheckIcon is not available */}
+    <span className="text-muted-foreground">{children}</span>
+  </li>
+);
+
+export default function PricingPage() {
+  return (
+    <div className="container mx-auto px-4 py-12">
+      <div className="text-center mb-12">
+        <h1 className="text-4xl md:text-5xl font-bold text-primary">Pricing Plans</h1>
+        <p className="text-lg text-muted-foreground mt-2">
+          Choose the plan that's right for your needs. Simple, transparent pricing.
+        </p>
+      </div>
+
+      <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8 max-w-5xl mx-auto">
+        {/* Free Plan */}
+        <Card className="flex flex-col">
+          <CardHeader>
+            <CardTitle>Free</CardTitle>
+            <CardDescription>Perfect for getting started and personal projects.</CardDescription>
+          </CardHeader>
+          <CardContent className="flex-grow space-y-4">
+            <p className="text-4xl font-bold">$0<span className="text-sm font-normal text-muted-foreground">/month</span></p>
+            <ul className="space-y-2">
+              <FeatureListItem>100 validations/month</FeatureListItem>
+              <FeatureListItem>Basic API Access</FeatureListItem>
+              <FeatureListItem>Community Support</FeatureListItem>
+            </ul>
+          </CardContent>
+          <CardFooter>
+            <Button variant="outline" className="w-full">Get Started</Button>
+          </CardFooter>
+        </Card>
+
+        {/* Pro Plan - Highlighted */}
+        <Card className="flex flex-col border-2 border-primary shadow-lg relative">
+          <div className="absolute top-0 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-primary text-primary-foreground px-3 py-1 text-sm font-semibold rounded-full">
+            Most Popular
+          </div>
+          <CardHeader className="pt-10"> {/* Added padding top to account for badge */}
+            <CardTitle>Pro</CardTitle>
+            <CardDescription>Ideal for growing businesses and applications.</CardDescription>
+          </CardHeader>
+          <CardContent className="flex-grow space-y-4">
+            <p className="text-4xl font-bold">$29<span className="text-sm font-normal text-muted-foreground">/month</span></p>
+            <ul className="space-y-2">
+              <FeatureListItem>5,000 validations/month</FeatureListItem>
+              <FeatureListItem>Full API Access</FeatureListItem>
+              <FeatureListItem>Webhook Support</FeatureListItem>
+              <FeatureListItem>Email Support</FeatureListItem>
+            </ul>
+          </CellContent>
+          <CardFooter>
+            <Button className="w-full">Choose Pro</Button>
+          </CardFooter>
+        </Card>
+
+        {/* Enterprise Plan */}
+        <Card className="flex flex-col">
+          <CardHeader>
+            <CardTitle>Enterprise</CardTitle>
+            <CardDescription>For large-scale applications and custom needs.</CardDescription>
+          </CardHeader>
+          <CardContent className="flex-grow space-y-4">
+            <p className="text-4xl font-bold">Custom</p>
+            <ul className="space-y-2">
+              <FeatureListItem>Unlimited validations</FeatureListItem>
+              <FeatureListItem>Full API Access & Webhooks</FeatureListItem>
+              <FeatureListItem>Dedicated Support & SLAs</FeatureListItem>
+              <FeatureListItem>Custom Integrations</FeatureListItem>
+            </ul>
+          </CardContent>
+          <CardFooter>
+            <Button variant="outline" className="w-full">Contact Sales</Button>
+          </CardFooter>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/validate-email/page.tsx
+++ b/frontend/app/validate-email/page.tsx
@@ -1,0 +1,119 @@
+"use client"; 
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { InputOTP, InputOTPGroup, InputOTPSlot } from "@/components/ui/input-otp"; // Verify this path
+
+export default function ValidateEmailPage() {
+  const [step, setStep] = useState<"email" | "otp">("email");
+  const [email, setEmail] = useState<string>("");
+  const [otp, setOtp] = useState<string>("");
+
+  const handleEmailSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    console.log("OTP requested for:", email);
+    setStep("otp"); 
+  };
+
+  const handleOtpSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    console.log("OTP submitted:", otp, "for email:", email);
+    alert(`OTP ${otp} submitted for ${email}! (This is a demo)`);
+    // Potentially reset state here or redirect
+  };
+
+  return (
+    <div className="flex justify-center items-center min-h-[calc(100vh-10rem)] p-4">
+      <Card className="w-full max-w-md shadow-lg">
+        <CardHeader>
+          <CardTitle className="text-2xl font-bold text-primary text-center">
+            {step === "email" ? "Validate Your Email" : "Enter Verification Code"}
+          </CardTitle>
+          <CardDescription className="text-center">
+            {step === "email"
+              ? "Enter your email address to receive a one-time password."
+              : `A 6-digit code has been sent to ${email}.`}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {step === "email" && (
+            <form onSubmit={handleEmailSubmit} className="space-y-6">
+              <div className="space-y-2">
+                <Label htmlFor="email" className="text-muted-foreground">Email Address</Label>
+                <Input
+                  id="email"
+                  type="email"
+                  placeholder="you@example.com"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  required
+                  className="text-base"
+                />
+              </div>
+              <Button type="submit" className="w-full text-base py-3">Send OTP</Button>
+            </form>
+          )}
+
+          {step === "otp" && (
+            <form onSubmit={handleOtpSubmit} className="space-y-8 flex flex-col items-center">
+              <div className="space-y-2 flex flex-col items-center">
+                <Label htmlFor="otp-input" className="text-muted-foreground">Verification Code</Label>
+                <InputOTP 
+                  id="otp-input"
+                  maxLength={6} 
+                  value={otp} 
+                  onChange={(value) => setOtp(value)}
+                  name="otp" // Added name attribute
+                  autoComplete="one-time-code" // Added autocomplete attribute
+                >
+                  <InputOTPGroup>
+                    <InputOTPSlot index={0} />
+                    <InputOTPSlot index={1} />
+                    <InputOTPSlot index={2} />
+                  </InputOTPGroup>
+                  {/* No separator for a continuous 6-digit code as per common practice, unless specifically requested */}
+                  <InputOTPGroup>
+                    <InputOTPSlot index={3} />
+                    <InputOTPSlot index={4} />
+                    <InputOTPSlot index={5} />
+                  </InputOTPGroup>
+                </InputOTP>
+                <p className="text-xs text-muted-foreground pt-1">Enter the 6-digit code sent to your email.</p>
+              </div>
+              
+              <Button type="submit" className="w-full text-base py-3">Validate Email</Button>
+              
+              <div className="flex flex-col sm:flex-row justify-between items-center w-full space-y-2 sm:space-y-0 sm:space-x-2">
+                <Button 
+                  variant="link" 
+                  size="sm" 
+                  onClick={() => {
+                    console.log("Resend OTP for:", email); 
+                    alert("Resend OTP clicked (demo)");
+                  }}
+                  className="text-primary hover:text-primary/80 p-0"
+                >
+                  Resend OTP
+                </Button>
+                <Button 
+                  variant="outline" 
+                  size="sm" 
+                  onClick={() => {
+                    setStep("email");
+                    setOtp(""); 
+                  }}
+                  className="w-full sm:w-auto"
+                >
+                  Change Email
+                </Button>
+              </div>
+            </form>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/app/webhooks/page.tsx
+++ b/frontend/app/webhooks/page.tsx
@@ -1,0 +1,79 @@
+export default function WebhooksPage() {
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-4xl font-bold text-primary mb-8">Webhooks Integration</h1>
+
+      <section id="introduction" className="mb-12 space-y-4">
+        <h2 className="text-2xl font-semibold text-primary/90">Introduction to Webhooks</h2>
+        <p className="text-muted-foreground">
+          Webhooks allow your application to receive real-time notifications about events that happen in our email validation service. 
+          Instead of polling our API, you can subscribe to events and we'll send an HTTP POST payload to your configured webhook URL when an event occurs.
+        </p>
+        <p className="text-muted-foreground">
+          Common use cases include updating your local database when an email is successfully validated, or triggering custom workflows based on validation outcomes.
+        </p>
+      </section>
+
+      <section id="setup" className="mb-12 space-y-4">
+        <h2 className="text-2xl font-semibold text-primary/90">Setting Up a Webhook</h2>
+        <p className="text-muted-foreground">
+          1. Go to your account dashboard (link to be added).
+        </p>
+        <p className="text-muted-foreground">
+          2. Navigate to the 'Webhooks' section in your settings.
+        </p>
+        <p className="text-muted-foreground">
+          3. Click 'Add Endpoint' and provide your HTTPS webhook URL.
+        </p>
+        <p className="text-muted-foreground">
+          <strong>Security:</strong> We sign each webhook event we send using a unique secret key for each endpoint. This signature is passed in the <code className="bg-muted px-1 py-0.5 rounded">X-Webhook-Signature</code> HTTP header. Verify this signature to ensure the request came from us and was not tampered with. Your endpoint secrets are available in your dashboard.
+        </p>
+      </section>
+
+      <section id="event-types" className="mb-12 space-y-4">
+        <h2 className="text-2xl font-semibold text-primary/90">Event Types</h2>
+        <p className="text-muted-foreground">We currently support the following event types:</p>
+        <ul className="list-disc list-inside text-muted-foreground space-y-2 pl-4">
+          <li><code className="bg-muted px-1 py-0.5 rounded">email.validation.succeeded</code>: Triggered when an email is successfully validated via OTP.</li>
+          <li><code className="bg-muted px-1 py-0.5 rounded">email.validation.failed</code>: Triggered if an email cannot be validated (e.g., invalid format, OTP expired, too many attempts).</li>
+          <li><code className="bg-muted px-1 py-0.5 rounded">otp.requested</code>: Triggered when an OTP has been generated and sent for an email.</li>
+          {/* Add more placeholder events as needed */}
+        </ul>
+      </section>
+
+      <section id="payload-structure" className="mb-12 space-y-4">
+        <h2 className="text-2xl font-semibold text-primary/90">Payload Structure</h2>
+        <p className="text-muted-foreground">All webhook events follow a similar JSON structure:</p>
+        <pre className="bg-muted p-4 rounded-md text-sm overflow-x-auto"><code>
+{`{
+  "event_id": "evt_123abc456def",
+  "event_type": "email.validation.succeeded",
+  "api_version": "v1",
+  "created_at": 1678886400,
+  "data": {
+    "object": {
+      // Event-specific data will be here
+      "email": "user@example.com",
+      "status": "verified",
+      // ... other relevant fields
+    }
+  }
+}`}
+        </code></pre>
+        <p className="text-muted-foreground mt-4">
+          The <code className="bg-muted px-1 py-0.5 rounded">data.object</code> will contain the details specific to the event type. For example, for <code className="bg-muted px-1 py-0.5 rounded">email.validation.succeeded</code>, it might include the validated email address and any associated metadata.
+        </p>
+      </section>
+
+      <section id="best-practices" className="mb-12 space-y-4">
+        <h2 className="text-2xl font-semibold text-primary/90">Best Practices</h2>
+        <ul className="list-disc list-inside text-muted-foreground space-y-2 pl-4">
+          <li><strong>Respond quickly:</strong> Your endpoint should acknowledge receipt of the event by returning a 2xx HTTP status code within a few seconds. If we don't receive a timely success response, we may consider the delivery failed and retry.</li>
+          <li><strong>Verify signatures:</strong> Always verify the webhook signature to ensure the request is legitimate.</li>
+          <li><strong>Handle retries:</strong> Our system may send the same event more than once if acknowledgement fails. Design your endpoint to be idempotent.</li>
+          <li><strong>Use HTTPS:</strong> Always use an HTTPS URL for your webhook endpoint to ensure data is encrypted in transit.</li>
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/frontend/components/site-header.tsx
+++ b/frontend/components/site-header.tsx
@@ -1,17 +1,50 @@
-import { Separator } from "@/components/ui/separator"
-import { SidebarTrigger } from "@/components/ui/sidebar"
+import Link from "next/link";
+// import { Separator } from "@/components/ui/separator"; // No longer needed
+import { SidebarTrigger } from "@/components/ui/sidebar"; // Assuming this is for a mobile nav
+import { Button } from "@/components/ui/button"; // For styling links
 
 export function SiteHeader() {
+  const navLinks = [
+    { href: "/", label: "Home" },
+    { href: "/api-docs", label: "API Docs" },
+    { href: "/validate-email", label: "Demo" },
+    { href: "/webhooks", label: "Webhooks" },
+    { href: "/pricing", label: "Pricing" },
+    { href: "/contact", label: "Contact" },
+  ];
+
   return (
-    <header className="group-has-data-[collapsible=icon]/sidebar-wrapper:h-12 flex h-12 shrink-0 items-center gap-2 border-b transition-[width,height] ease-linear">
-      <div className="flex w-full items-center gap-1 px-4 lg:gap-2 lg:px-6">
+    <header className="group-has-data-[collapsible=icon]/sidebar-wrapper:h-12 flex h-16 shrink-0 items-center gap-2 border-b transition-[width,height] ease-linear px-4 lg:px-6">
+      {/* Mobile Nav Trigger */}
+      <div className="lg:hidden"> {/* Show trigger only on smaller screens */}
         <SidebarTrigger className="-ml-1" />
-        <Separator
-          orientation="vertical"
-          className="mx-2 data-[orientation=vertical]:h-4"
-        />
-        <h1 className="text-base font-medium">Documents</h1>
       </div>
+      
+      {/* Site Title/Logo Area */}
+      <div className="flex items-center">
+        <Link href="/" className="text-lg font-semibold text-primary">
+          EmailValidator Inc. {/* Placeholder service name */}
+        </Link>
+      </div>
+
+      {/* Desktop Navigation Links - Placed after title, hidden on small screens */}
+      <nav className="hidden lg:flex items-center gap-1 ml-auto"> {/* Reduced gap-4 to gap-1 for more links */}
+        {navLinks.map((link) => (
+          <Link
+            key={link.href}
+            href={link.href}
+            passHref
+            legacyBehavior // Required if Button is the child for Next.js 13+ Link with custom component
+          >
+            <Button variant="ghost" asChild size="sm"> {/* Added size="sm" for smaller buttons */}
+              {/* asChild allows Button to get props from Link, like href */}
+              <a>{link.label}</a>
+            </Button>
+          </Link>
+        ))}
+      </nav>
+      
+      {/* Original Separator and "Documents" title removed */}
     </header>
-  )
+  );
 }

--- a/frontend/components/ui/input-otp.tsx
+++ b/frontend/components/ui/input-otp.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+import * as React from "react"
+import { OTPInput, OTPInputContext } from "input-otp"
+import { Minus } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const InputOTP = React.forwardRef<
+  React.ElementRef<typeof OTPInput>,
+  React.ComponentPropsWithoutRef<typeof OTPInput>
+>(({ className, containerClassName, ...props }, ref) => (
+  <OTPInput
+    ref={ref}
+    containerClassName={cn(
+      "flex items-center gap-2 has-[:disabled]:opacity-50",
+      containerClassName
+    )}
+    className={cn("disabled:cursor-not-allowed", className)}
+    {...props}
+  />
+))
+InputOTP.displayName = "InputOTP"
+
+const InputOTPGroup = React.forwardRef<
+  React.ElementRef<"div">,
+  React.ComponentPropsWithoutRef<"div">
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("flex items-center", className)} {...props} />
+))
+InputOTPGroup.displayName = "InputOTPGroup"
+
+const InputOTPSlot = React.forwardRef<
+  React.ElementRef<"div">,
+  React.ComponentPropsWithoutRef<"div"> & { index: number }
+>(({ index, className, ...props }, ref) => {
+  const inputOTPContext = React.useContext(OTPInputContext)
+  const { char, hasFakeCaret, isActive } = inputOTPContext.slots[index]
+
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        "relative flex h-9 w-9 items-center justify-center border-y border-r border-input text-sm shadow-sm transition-all first:rounded-l-md first:border-l last:rounded-r-md",
+        isActive && "z-10 ring-1 ring-ring",
+        className
+      )}
+      {...props}
+    >
+      {char}
+      {hasFakeCaret && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <div className="h-4 w-px animate-caret-blink bg-foreground duration-1000" />
+        </div>
+      )}
+    </div>
+  )
+})
+InputOTPSlot.displayName = "InputOTPSlot"
+
+const InputOTPSeparator = React.forwardRef<
+  React.ElementRef<"div">,
+  React.ComponentPropsWithoutRef<"div">
+>(({ ...props }, ref) => (
+  <div ref={ref} role="separator" {...props}>
+    <Minus />
+  </div>
+))
+InputOTPSeparator.displayName = "InputOTPSeparator"
+
+export { InputOTP, InputOTPGroup, InputOTPSlot, InputOTPSeparator }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,6 +27,7 @@
         "@tanstack/react-table": "^8.21.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "input-otp": "^1.4.2",
         "lucide-react": "^0.511.0",
         "next": "15.1.8",
         "next-themes": "^0.4.6",
@@ -4786,6 +4787,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/input-otp": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/input-otp/-/input-otp-1.4.2.tgz",
+      "integrity": "sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/internal-slot": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "@tanstack/react-table": "^8.21.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "input-otp": "^1.4.2",
     "lucide-react": "^0.511.0",
     "next": "15.1.8",
     "next-themes": "^0.4.6",


### PR DESCRIPTION
This commit introduces the initial frontend structure and pages for the email validation service.

Key changes include:
- Theming: Implemented a green tint theme across the application using Tailwind CSS and CSS variables.
- Layout: Established a consistent layout with a site header and main content area.
- Landing Page: Developed a new landing page with sections for hero, features, how-it-works, and developer focus.
- Core Pages:
    - API Documentation: Added a structured page with placeholders for API details.
    - OTP Validation Page: Created a two-step form for email and OTP input using the shadcn input-otp component.
    - Webhooks Page: Added a page with placeholder information on webhook integration.
    - Pricing Page: Implemented a page with three distinct pricing tiers.
    - Contact Page: Developed a contact page with a form and alternative contact methods.
- Navigation: Updated the site header to include navigation links to all new pages for desktop view.

The `input-otp` component installation required your manual intervention after several of my attempts to automate it via various shadcn CLI commands failed due to deprecation or unhandled interactive prompts related to React 19 peer dependencies. The subsequent work incorporates this manually added component.

Further work will involve ensuring full responsive design across all pages and a final review.